### PR TITLE
Updated broken references to standalone expect.js

### DIFF
--- a/05-react-redux-writing-a-counter-reducer-with-tests/index.html
+++ b/05-react-redux-writing-a-counter-reducer-with-tests/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="https://wzrd.in/standalone/expect@22.4.3"></script>
+  <script src="https://unpkg.com/jest-expect-standalone@latest/dist/expect.min.js"></script>
 </head>
 <body>
   <script src="script.jsx"></script>

--- a/09-react-redux-avoiding-array-mutations-with-concat-slice-and-spread/index.html
+++ b/09-react-redux-avoiding-array-mutations-with-concat-slice-and-spread/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
 </head>
 <body>
-  <script src="https://wzrd.in/standalone/expect@22.4.3"></script>
+  <script src="https://unpkg.com/jest-expect-standalone@latest/dist/expect.min.js"></script>
   <script src="script.jsx"></script>
 </body>
 </html>

--- a/10-react-redux-avoiding-object-mutations-with-object-assign-and-spread/index.html
+++ b/10-react-redux-avoiding-object-mutations-with-object-assign-and-spread/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
 </head>
 <body>
-  <script src="https://wzrd.in/standalone/expect@22.4.3"></script>
+  <script src="https://unpkg.com/jest-expect-standalone@latest/dist/expect.min.js"></script>
   <script src="script.jsx"></script>
 </body>
 </html>

--- a/11-react-redux-writing-a-todo-list-reducer-adding-a-todo/index.html
+++ b/11-react-redux-writing-a-todo-list-reducer-adding-a-todo/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
 </head>
 <body>
-  <script src="https://wzrd.in/standalone/expect@22.4.3"></script>
+  <script src="https://unpkg.com/jest-expect-standalone@latest/dist/expect.min.js"></script>
   <script src="script.jsx"></script>
 </body>
 </html>

--- a/12-react-redux-writing-a-todo-list-reducer-toggling-a-todo/index.html
+++ b/12-react-redux-writing-a-todo-list-reducer-toggling-a-todo/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
 </head>
 <body>
-  <script src="https://wzrd.in/standalone/expect@22.4.3"></script>
+  <script src="https://unpkg.com/jest-expect-standalone@latest/dist/expect.min.js"></script>
   <script src="script.jsx"></script>
 </body>
 </html>

--- a/13-react-redux-reducer-composition-with-arrays/index.html
+++ b/13-react-redux-reducer-composition-with-arrays/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="https://wzrd.in/standalone/expect@22.4.3"></script>
+  <script src="https://unpkg.com/jest-expect-standalone@latest/dist/expect.min.js"></script>
 </head>
 <body>
 	<script src="script.jsx"></script>

--- a/16-javascript-redux-implementing-combinereducers-from-scratch/index.html
+++ b/16-javascript-redux-implementing-combinereducers-from-scratch/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>JS Bin</title>
-  <script src="https://wzrd.in/standalone/expect@22.4.3"></script>
+  <script src="https://unpkg.com/jest-expect-standalone@latest/dist/expect.min.js"></script>
   <script src="https://unpkg.com/redux@4.0.0/dist/redux.js"></script>
 </head>
 <body>


### PR DESCRIPTION
The wzrd.in no longer working now, hence updated the references to a standalone version maintained [here](https://github.com/valera-rozuvan/jest-expect-standalone).
